### PR TITLE
Update metar data fetching URL.

### DIFF
--- a/wmfrog/Src/weather.pl
+++ b/wmfrog/Src/weather.pl
@@ -27,7 +27,7 @@
 #       faster, however this might get broken if NOAA change their
 #       webpage layout in wich case you should choose ftp.
 
-$mode="http"; # html || ftp
+$mode="ftp"; # html || ftp
 
 $debug = 0; # turn On/Off debugging
 
@@ -54,6 +54,8 @@ mkdir $tmpfolder;
 
 $html = "http://weather.noaa.gov/cgi-bin/mgetmetar.pl?cccc=${station}";
 $ftp  = "ftp://weather.noaa.gov/data/observations/metar/stations/${station}.TXT";
+$ftp  = "ftp://tgftp.nws.noaa.gov/data/observations/metar/stations/${station}.TXT";
+
 $url  = $html;
 
 if ( $mode eq "ftp" )


### PR DESCRIPTION
In accordance with NWS Service Change Notice 16-16 [1], the weather.noaa.gov
service, which wmfrog uses to obtain weather information, was discontinued
on August 3, 2016.

However, the data is still available on the National Weather Service's FTP
server [2].

Patch by Bastien Mourgues <bastien.mourgues@free.fr>, reported in Debian
bug #843873.

[1] http://www.nws.noaa.gov/om/notification/scn16-16wngccb.htm
[2] ftp://tgftp.nws.noaa.gov/data/observations/metar/stations/
[3] https://bugs.debian.org/843873