### PR TITLE
Fix multiple definitions of several variables.

### DIFF
--- a/wmfrog/Src/xutils.c
+++ b/wmfrog/Src/xutils.c
@@ -40,6 +40,15 @@
 #include "xutils.h"
 
 
+/*
+ * Global variables.
+ */
+Display		*display;
+Window          Root;
+Window          iconwin, win;
+int             screen;
+int             DisplayDepth;
+
 
 /*
  *   X11 Variables 

--- a/wmfrog/Src/xutils.h
+++ b/wmfrog/Src/xutils.h
@@ -18,11 +18,11 @@ typedef struct {
 /*
  *   Global variable
  */
-Display		*display;
-Window          Root;
-Window          iconwin, win;
-int             screen; 
-int             DisplayDepth;
+extern Display		*display;
+extern Window          Root;
+extern Window          iconwin, win;
+extern int             screen;
+extern int             DisplayDepth;
 
 
 


### PR DESCRIPTION
Patch by Jeremy Sowden to fix
[Debian bug #957944](https://bugs.debian.org/957944):

> Package: src:wmfrog
> Version: 0.3.1+git20161115-2
> Severity: normal
> Tags: sid bullseye
> User: debian-gcc@lists.debian.org
> Usertags: ftbfs-gcc-10
>
> Please keep this issue open in the bug tracker for the package it
> was filed for.  If a fix in another package is required, please
> file a bug for the other package (or clone), and add a block in this
> package. Please keep the issue open until the package can be built in
> a follow-up test rebuild.
>
> The package fails to build in a test rebuild on at least amd64 with
> gcc-10/g++-10, but succeeds to build with gcc-9/g++-9. The
> severity of this report will be raised before the bullseye release,
> so nothing has to be done for the buster release.
>
> The full build log can be found at:
> http://people.debian.org/~doko/logs/gcc10-20200225/wmfrog_0.3.1+git20161115-2_unstable_gcc10.log
> The last lines of the build log are at the end of this report.
>
> To build with GCC 10, either set CC=gcc-10 CXX=g++-10 explicitly,
> or install the gcc, g++, gfortran, ... packages from experimental.
>
>     apt-get -t=experimental install g++
>
> Common build failures are new warnings resulting in build failures with
> -Werror turned on, or new/dropped symbols in Debian symbols files.
> For other C/C++ related build failures see the porting guide at
> http://gcc.gnu.org/gcc-10/porting_to.html
>
> [...]
>
> User Environment
> ----------------
>
>     APT_CONFIG=/var/lib/sbuild/apt.conf
>     HOME=/sbuild-nonexistent
>     LANG=C.UTF-8
>     LC_ALL=C.UTF-8
>     LOGNAME=user42
>     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
>     SCHROOT_ALIAS_NAME=unstable
>     SCHROOT_CHROOT_NAME=sid-amd64-sbuild
>     SCHROOT_COMMAND=env
>     SCHROOT_GID=1001
>     SCHROOT_GROUP=user42
>     SCHROOT_SESSION_ID=sid-amd64-sbuild-4d125c8d-27c2-48c5-b9a6-d61343929427
>     SCHROOT_UID=1001
>     SCHROOT_USER=user42
>     SHELL=/bin/sh
>     USER=user42
>
> dpkg-buildpackage
> -----------------
>
>     Command: dpkg-buildpackage -us -uc -b -rfakeroot
>     dpkg-buildpackage: info: source package wmfrog
>     dpkg-buildpackage: info: source version 0.3.1+git20161115-2
>     dpkg-buildpackage: info: source distribution unstable
>     dpkg-buildpackage: info: source changed by Jeremy Sowden <jeremy@azazel.net>
>      dpkg-source --before-build .
>     dpkg-buildpackage: info: host architecture amd64
>      debian/rules clean
>     dh clean --sourcedirectory=Src
>        dh_auto_clean -O--sourcedirectory=Src
>     	cd Src && make -j4 clean
>     make[1]: Entering directory '/<<PKGBUILDDIR>>/Src'
>     for i in wmfrog.o xutils.o ; do \
>     	rm -f $i; \
>     done
>     rm -f wmfrog
>     make[1]: Leaving directory '/<<PKGBUILDDIR>>/Src'
>        dh_autoreconf_clean -O--sourcedirectory=Src
>        dh_clean -O--sourcedirectory=Src
>      debian/rules binary
>     dh binary --sourcedirectory=Src
>        dh_update_autotools_config -O--sourcedirectory=Src
>        dh_autoreconf -O--sourcedirectory=Src
>        dh_auto_configure -O--sourcedirectory=Src
>        debian/rules override_dh_auto_build
>     make[1]: Entering directory '/<<PKGBUILDDIR>>'
>     dh_auto_build --sourcedirectory=Src \
>     	-- CFLAGS="-g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security"
>     	cd Src && make -j4 "INSTALL=install --strip-program=true" "CFLAGS=-g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security"
>     make[2]: Entering directory '/<<PKGBUILDDIR>>/Src'
>     gcc -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -DLinux -c wmfrog.c -o wmfrog.o -I/usr/X11R6/include/X11 -I/usr/X11R6/include
>     gcc -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -DLinux -c xutils.c -o xutils.o -I/usr/X11R6/include/X11 -I/usr/X11R6/include
>     gcc -Wl,-z,relro -Wl,-z,now  -o wmfrog wmfrog.o xutils.o -I/usr/X11R6/include/X11 -I/usr/X11R6/include -L/usr/X11R6/lib -lXpm -lX11 -lXext
>     /usr/bin/ld: xutils.o:./Src/xutils.h:23: multiple definition of `iconwin'; wmfrog.o:./Src/xutils.h:23: first defined here
>     /usr/bin/ld: xutils.o:./Src/xutils.h:21: multiple definition of `display'; wmfrog.o:./Src/xutils.h:21: first defined here
>     /usr/bin/ld: xutils.o:./Src/xutils.h:23: multiple definition of `win'; wmfrog.o:./Src/xutils.h:23: first defined here
>     /usr/bin/ld: xutils.o:./Src/xutils.h:24: multiple definition of `screen'; wmfrog.o:./Src/xutils.h:24: first defined here
>     /usr/bin/ld: xutils.o:./Src/xutils.h:22: multiple definition of `Root'; wmfrog.o:./Src/xutils.h:22: first defined here
>     /usr/bin/ld: xutils.o:./Src/xutils.h:25: multiple definition of `DisplayDepth'; wmfrog.o:./Src/xutils.h:25: first defined here
>     collect2: error: ld returned 1 exit status
>     make[2]: *** [Makefile:23: wmfrog] Error 1
>     make[2]: Leaving directory '/<<PKGBUILDDIR>>/Src'
>     dh_auto_build: error: cd Src && make -j4 "INSTALL=install --strip-program=true" "CFLAGS=-g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security" returned exit code 2
>     make[1]: *** [debian/rules:9: override_dh_auto_build] Error 25
>     make[1]: Leaving directory '/<<PKGBUILDDIR>>'
>     make: *** [debian/rules:6: binary] Error 2
>     dpkg-buildpackage: error: debian/rules binary subprocess returned exit status 2
